### PR TITLE
feat(vercel): add standalone /api/health serverless function

### DIFF
--- a/packages/backend/api/health.ts
+++ b/packages/backend/api/health.ts
@@ -1,0 +1,4 @@
+export default function handler(_req: any, res: any) {
+  res.status(200).json({ status: 'ok', from: 'vercel-function', timestamp: new Date().toISOString() });
+}
+


### PR DESCRIPTION
- Add api/health.ts serverless function that returns status ok
- Useful to verify deployment and function routing independently of the Express app

After merging, test:
- https://finora-backend-qwg4.vercel.app/api/health
- https://finora-backend-qwg4.vercel.app/health (should be served by Express via api/index.ts)


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author