### PR TITLE
chore(vercel): declare outputDirectory=public and add public/ placeholder

### DIFF
--- a/packages/backend/public/README.md
+++ b/packages/backend/public/README.md
@@ -1,0 +1,6 @@
+This folder exists to satisfy Vercel's Output Directory requirement for the backend project.
+
+- It contains no static assets.
+- Serverless functions under /api are the primary entry points.
+- All routes are forwarded to api/index.ts via vercel.json.
+

--- a/packages/backend/vercel.json
+++ b/packages/backend/vercel.json
@@ -3,6 +3,7 @@
   "builds": [
     { "src": "api/index.ts", "use": "@vercel/node" }
   ],
+  "outputDirectory": "public",
   "functions": {
     "api/index.ts": {
       "runtime": "nodejs18.x",


### PR DESCRIPTION
- Add packages/backend/public/ placeholder so Vercel UI can require Output Directory
- Set outputDirectory: "public" in packages/backend/vercel.json
- Functions remain primary entry points; public has no static assets

After merge, set Output Directory to public in Vercel settings if required and Redeploy.

Health checks:
- https://finora-backend-qwg4.vercel.app/api/health
- https://finora-backend-qwg4.vercel.app/health

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author