### PR TITLE
backend(vercel): Build Output API for Serverless Functions with Output Directory='.'

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "nodemon src/index.ts",
     "build": "tsc",
-    "vercel-build": "echo 'Skipping build (serverless functions only)'",
+    "vercel-build": "node scripts/build-vercel-output.js",
     "start": "node dist/index.js",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/packages/backend/scripts/build-vercel-output.js
+++ b/packages/backend/scripts/build-vercel-output.js
@@ -1,0 +1,101 @@
+/* Build Output API v3 generator for Vercel
+ * - Compiles TypeScript (src -> dist)
+ * - Emits .vercel/output with serverless functions for:
+ *   - api/health
+ *   - api/index (Express app)
+ * - Adds routes mapping /api/* to the functions
+ */
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const root = process.cwd();
+const outDir = path.join(root, '.vercel', 'output');
+const functionsDir = path.join(outDir, 'functions');
+
+function ensureDir(p) {
+  fs.mkdirSync(p, { recursive: true });
+}
+
+function writeJSON(p, obj) {
+  fs.writeFileSync(p, JSON.stringify(obj, null, 2));
+}
+
+function writeFile(p, content) {
+  fs.writeFileSync(p, content);
+}
+
+function buildTypescript() {
+  console.log('> Compiling TypeScript (npm run build)');
+  execSync('npm run build', { stdio: 'inherit' });
+}
+
+function emitHealthFunction() {
+  const funcBase = path.join(functionsDir, 'api', 'health.func');
+  ensureDir(funcBase);
+
+  // Minimal health handler
+  writeFile(
+    path.join(funcBase, 'index.js'),
+    `module.exports = function handler(_req, res) {
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ status: 'ok', from: 'vercel-output-func', timestamp: new Date().toISOString() }));
+    };\n`
+  );
+
+  writeJSON(path.join(funcBase, '.vc-config.json'), {
+    runtime: 'nodejs18.x',
+    handler: 'index.js',
+  });
+}
+
+function emitIndexFunction() {
+  const funcBase = path.join(functionsDir, 'api', 'index.func');
+  ensureDir(funcBase);
+
+  // __dirname at runtime will be <project>/.vercel/output/functions/api/index.func
+  // dist/index.js is located at <project>/dist/index.js
+  // So the relative path to dist is '../../../../../dist/index.js'
+  writeFile(
+    path.join(funcBase, 'index.js'),
+    `const path = require('path');
+const app = require(path.resolve(__dirname, '../../../../../dist/index.js')).default;
+module.exports = function handler(req, res) {
+  return app(req, res);
+};\n`
+  );
+
+  writeJSON(path.join(funcBase, '.vc-config.json'), {
+    runtime: 'nodejs18.x',
+    handler: 'index.js',
+  });
+}
+
+function emitConfig() {
+  ensureDir(outDir);
+  // Minimal static dir so deployments that expect static output don't error
+  ensureDir(path.join(outDir, 'static'));
+
+  // Build Output API v3 config with routes
+  writeJSON(path.join(outDir, 'config.json'), {
+    version: 3,
+    routes: [
+      { src: '/api/health', dest: 'api/health' },
+      { src: '/api/(.*)', dest: 'api/index' },
+    ],
+  });
+}
+
+function main() {
+  buildTypescript();
+  ensureDir(functionsDir);
+  emitHealthFunction();
+  emitIndexFunction();
+  emitConfig();
+  console.log('> Vercel Build Output generated in .vercel/output');
+}
+
+main();
+


### PR DESCRIPTION
Summary
- Generate .vercel/output (Build Output API v3) so we can keep Output Directory set to "." and still deploy serverless functions for the backend.
- Update packages/backend/package.json to run the generator during Vercel build via `npm run vercel-build`.

Changes
- packages/backend/scripts/build-vercel-output.js: builds TS and emits functions:
  - functions/api/health.func (simple JSON health)
  - functions/api/index.func (wraps Express app from dist/index.js)
  - config.json routes: `/api/health` and `/api/(.*)` -> respective functions
- packages/backend/package.json: replace vercel-build script to `node scripts/build-vercel-output.js`.

How to configure Vercel (Backend project)
- Root Directory: `packages/backend`
- Build Command: `npm run vercel-build`
- Output Directory: `.` (override ON)

After deploy, verify:
- Project → Functions shows `api/health` and `api/index`
- https://<backend-domain>/api/health returns JSON
- https://<backend-domain>/api/search?q=AAPL works via Express routed through `api/index`.

Why this is needed
- When Output Directory is set, Vercel expects Build Output artifacts and ignores vercel.json build detection. This PR provides the necessary artifacts so serverless functions deploy correctly even with Output Directory required to be ".".


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author